### PR TITLE
Allow to only pull from temporary files

### DIFF
--- a/proofs/files.php
+++ b/proofs/files.php
@@ -275,12 +275,13 @@ return static function() {
     );
 
     yield proof(
-        'IO::files()->temporary()',
+        'IO::files()->temporary()->read()',
         given($strings),
         static function($assert, $chunks) {
             $read = IO::fromAmbientAuthority()
                 ->files()
                 ->temporary(Sequence::of(...$chunks)->map(Str::of(...)))
+                ->map(static fn($temporary) => $temporary->read())
                 ->match(
                     static fn($read) => $read,
                     static fn() => null,

--- a/proofs/files.php
+++ b/proofs/files.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 use Innmind\IO\{
     IO,
     Files\Read,
+    Files\Temporary\Pull,
 };
 use Innmind\Url\Path;
 use Innmind\Immutable\{
@@ -306,6 +307,46 @@ return static function() {
                     ->fold(new Concat)
                     ->toString(),
                 'Temporary file should be accessible multiple times',
+            );
+        },
+    );
+
+    yield proof(
+        'IO::files()->temporary()->pull()',
+        given(
+            $strings,
+            Set::integers()->between(1, 100),
+            Set::of(...Str\Encoding::cases()),
+        ),
+        static function($assert, $chunks, $size, $encoding) {
+            $pull = IO::fromAmbientAuthority()
+                ->files()
+                ->temporary(Sequence::of(...$chunks)->map(Str::of(...)))
+                ->flatMap(static fn($temporary) => $temporary->pull())
+                ->match(
+                    static fn($pull) => $pull->watch()->toEncoding($encoding),
+                    static fn() => null,
+                );
+
+            $assert
+                ->object($pull)
+                ->instance(Pull::class);
+
+            $expected = \implode('', $chunks);
+            $read = '';
+
+            do {
+                $chunk = $pull
+                    ->chunk($size)
+                    ->unwrap();
+
+                $assert->same($encoding, $chunk->encoding());
+                $read .= $chunk->toString();
+            } while (!$chunk->empty());
+
+            $assert->same(
+                $expected,
+                $read,
             );
         },
     );

--- a/src/Files.php
+++ b/src/Files.php
@@ -5,6 +5,7 @@ namespace Innmind\IO;
 
 use Innmind\IO\{
     Files\Read,
+    Files\Temporary,
     Files\Write,
     Internal\Capabilities,
 };
@@ -43,7 +44,7 @@ final class Files
     /**
      * @param Sequence<Str> $chunks
      *
-     * @return Attempt<Read>
+     * @return Attempt<Temporary>
      */
     public function temporary(Sequence $chunks): Attempt
     {
@@ -56,7 +57,7 @@ final class Files
             ->flatMap(
                 static fn($tmp) => Write::temporary($capabilities, $tmp)
                     ->sink($chunks)
-                    ->map(static fn() => Read::temporary($capabilities, $tmp)),
+                    ->map(static fn() => Temporary::of($capabilities, $tmp)),
             );
     }
 }

--- a/src/Files/Temporary.php
+++ b/src/Files/Temporary.php
@@ -4,9 +4,11 @@ declare(strict_types = 1);
 namespace Innmind\IO\Files;
 
 use Innmind\IO\{
+    Files\Temporary\Pull,
     Internal,
     Internal\Capabilities,
 };
+use Innmind\Immutable\Attempt;
 
 final class Temporary
 {
@@ -29,5 +31,15 @@ final class Temporary
     public function read(): Read
     {
         return Read::temporary($this->capabilities, $this->stream);
+    }
+
+    /**
+     * @return Attempt<Pull>
+     */
+    public function pull(): Attempt
+    {
+        return $this->stream->rewind()->map(
+            fn() => Pull::of($this->capabilities, $this->stream),
+        );
     }
 }

--- a/src/Files/Temporary.php
+++ b/src/Files/Temporary.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\IO\Files;
+
+use Innmind\IO\{
+    Internal,
+    Internal\Capabilities,
+};
+
+final class Temporary
+{
+    private function __construct(
+        private Capabilities $capabilities,
+        private Internal\Stream $stream,
+    ) {
+    }
+
+    /**
+     * @internal
+     */
+    public static function of(
+        Capabilities $capabilities,
+        Internal\Stream $stream,
+    ): self {
+        return new self($capabilities, $stream);
+    }
+
+    public function read(): Read
+    {
+        return Read::temporary($this->capabilities, $this->stream);
+    }
+}

--- a/src/Files/Temporary/Pull.php
+++ b/src/Files/Temporary/Pull.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\IO\Files\Temporary;
+
+use Innmind\IO\{
+    Stream\Size,
+    Internal,
+    Internal\Capabilities,
+    Internal\Watch,
+};
+use Innmind\Immutable\{
+    Str,
+    Maybe,
+    Attempt,
+};
+
+final class Pull
+{
+    /**
+     * @param Maybe<Str\Encoding> $encoding
+     */
+    private function __construct(
+        private Internal\Stream $stream,
+        private Watch $watch,
+        private Maybe $encoding,
+    ) {
+    }
+
+    /**
+     * @internal
+     */
+    public static function of(
+        Capabilities $capabilities,
+        Internal\Stream $stream,
+    ): self {
+        /** @var Maybe<Str\Encoding> */
+        $encoding = Maybe::nothing();
+
+        return new self(
+            $stream,
+            $capabilities->watch(),
+            $encoding,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function toEncoding(Str\Encoding $encoding): self
+    {
+        return new self(
+            $this->stream,
+            $this->watch,
+            Maybe::just($encoding),
+        );
+    }
+
+    /**
+     * This is only useful in case the code is called in an asynchronous context
+     * as it allows the current code to inform the event loop we're doing IO.
+     *
+     * Otherwise this call is useless as files are always ready to be read.
+     *
+     * @psalm-mutation-free
+     */
+    public function watch(): self
+    {
+        return new self(
+            $this->stream,
+            $this->watch->waitForever(),
+            $this->encoding,
+        );
+    }
+
+    /**
+     * @return Maybe<Size>
+     */
+    public function size(): Maybe
+    {
+        return $this->stream->size();
+    }
+
+    /**
+     * @param int<1, max> $size
+     *
+     * @return Attempt<Str>
+     */
+    public function chunk(int $size): Attempt
+    {
+        $stream = $this->stream;
+        $wait = Internal\Stream\Wait::of($this->watch, $stream);
+
+        // we yield an empty line when the read() call doesn't return anything
+        // otherwise it will fail to load empty streams or streams ending with
+        // the "end of line" character
+        $chunk = $wait()
+            ->flatMap(static fn($stream) => $stream->read($size))
+            ->recover(static fn($e) => match ($stream->end()) {
+                true => Attempt::result(Str::of('')),
+                false => Attempt::error($e),
+            });
+
+        return $this->encoding->match(
+            static fn($encoding) => $chunk->map(
+                static fn($chunk) => $chunk->toEncoding($encoding),
+            ),
+            static fn() => $chunk,
+        );
+    }
+}


### PR DESCRIPTION
This is a compatibility feature to be used for curl in `innmind/http-transport`.

It shouldn't be used elsewhere.