### PR TITLE
Allow to close a temporary file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\IO\Files\Temporary::close()`
+
 ## 3.1.0 - 2025-04-21
 
 ### Added

--- a/documentation/files/temporary.md
+++ b/documentation/files/temporary.md
@@ -47,3 +47,9 @@ You can then use it in 2 ways:
     ```
 
     The call to `->chunk()` is stateful as it remembers the position in the file. This means that you can only read forward, and only once.
+
+Once you're down working with the file you can close it like this:
+
+```php
+$temporary->close()->unwrap();
+```

--- a/proofs/files.php
+++ b/proofs/files.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 use Innmind\IO\{
     IO,
     Files\Read,
+    Files\Temporary,
     Files\Temporary\Pull,
 };
 use Innmind\Url\Path;
@@ -347,6 +348,45 @@ return static function() {
             $assert->same(
                 $expected,
                 $read,
+            );
+        },
+    );
+
+    yield proof(
+        'IO::files()->temporary()->close()',
+        given($strings),
+        static function($assert, $chunks) {
+            $tmp = IO::fromAmbientAuthority()
+                ->files()
+                ->temporary(Sequence::of(...$chunks)->map(Str::of(...)))
+                ->match(
+                    static fn($tmp) => $tmp,
+                    static fn() => null,
+                );
+
+            $assert
+                ->object($tmp)
+                ->instance(Temporary::class);
+
+            $assert->not()->null(
+                $tmp->read()->size()->match(
+                    static fn($size) => $size,
+                    static fn() => null,
+                ),
+            );
+
+            $assert
+                ->object($tmp->close()->match(
+                    static fn($sideEffect) => $sideEffect,
+                    static fn() => null,
+                ))
+                ->instance(SideEffect::class);
+
+            $assert->null(
+                $tmp->read()->size()->match(
+                    static fn($size) => $size,
+                    static fn() => null,
+                ),
             );
         },
     );

--- a/src/Files/Temporary.php
+++ b/src/Files/Temporary.php
@@ -8,7 +8,10 @@ use Innmind\IO\{
     Internal,
     Internal\Capabilities,
 };
-use Innmind\Immutable\Attempt;
+use Innmind\Immutable\{
+    Attempt,
+    SideEffect,
+};
 
 final class Temporary
 {
@@ -52,5 +55,13 @@ final class Temporary
         return $this->stream->rewind()->map(
             fn() => Pull::of($this->capabilities, $this->stream),
         );
+    }
+
+    /**
+     * @return Attempt<SideEffect>
+     */
+    public function close(): Attempt
+    {
+        return $this->stream->close();
     }
 }


### PR DESCRIPTION
This is necessary for `innmind/http-transport`.