### PR TITLE
Add async support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Innmind\IO\IO::async()` (This is an internal feature for `innmind/async` that may introduce BC breaks in next minor versions)
+
 ## 3.3.1 - 2025-08-08
 
 ### Fixed

--- a/proofs/frames.php
+++ b/proofs/frames.php
@@ -22,7 +22,7 @@ return static function() {
         \fseek($tmp, 0);
 
         return Reader::of(
-            Wait::of(Watch::new(), Stream::of($tmp)),
+            Wait::of(Watch::sync(), Stream::of($tmp)),
             Maybe::just($data->encoding()),
         );
     };

--- a/src/IO.php
+++ b/src/IO.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Innmind\IO;
 
 use Innmind\IO\Internal\Capabilities;
+use Innmind\TimeContinuum\Clock;
 
 final class IO
 {
@@ -15,6 +16,16 @@ final class IO
     public static function fromAmbientAuthority(): self
     {
         return new self(Capabilities::fromAmbientAuthority());
+    }
+
+    /**
+     * This is an internal feature for the innmind/async package.
+     *
+     * @internal
+     */
+    public static function async(Clock $clock): self
+    {
+        return new self(Capabilities::async($clock));
     }
 
     public function files(): Files

--- a/src/Internal/Async/Resumable.php
+++ b/src/Internal/Async/Resumable.php
@@ -4,23 +4,33 @@ declare(strict_types = 1);
 namespace Innmind\IO\Internal\Async;
 
 use Innmind\IO\Internal\Watch\Ready;
+use Innmind\Immutable\Attempt;
 
 /**
  * @internal
  */
 final class Resumable
 {
+    /**
+     * @param Attempt<Ready> $ready
+     */
     private function __construct(
-        private Ready $ready,
+        private Attempt $ready,
     ) {
     }
 
-    public static function of(Ready $ready): self
+    /**
+     * @param Attempt<Ready> $ready
+     */
+    public static function of(Attempt $ready): self
     {
         return new self($ready);
     }
 
-    public function ready(): Ready
+    /**
+     * @return Attempt<Ready>
+     */
+    public function ready(): Attempt
     {
         return $this->ready;
     }

--- a/src/Internal/Async/Resumable.php
+++ b/src/Internal/Async/Resumable.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\IO\Internal\Async;
+
+use Innmind\IO\Internal\Watch\Ready;
+
+/**
+ * @internal
+ */
+final class Resumable
+{
+    private function __construct(
+        private Ready $ready,
+    ) {
+    }
+
+    public static function of(Ready $ready): self
+    {
+        return new self($ready);
+    }
+
+    public function ready(): Ready
+    {
+        return $this->ready;
+    }
+}

--- a/src/Internal/Async/Suspended.php
+++ b/src/Internal/Async/Suspended.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\IO\Internal\Async;
+
+use Innmind\IO\Internal\{
+    Watch\Ready,
+    Stream,
+    Socket\Server,
+};
+use Innmind\TimeContinuum\{
+    Clock,
+    PointInTime,
+    Period,
+};
+use Innmind\Immutable\{
+    Sequence,
+    Maybe,
+};
+
+/**
+ * @internal
+ */
+final class Suspended
+{
+    /**
+     * @param Maybe<Period> $timeout
+     * @param Sequence<Stream|Server> $read
+     * @param Sequence<Stream> $write
+     */
+    private function __construct(
+        private PointInTime $at,
+        private Maybe $timeout,
+        private Sequence $read,
+        private Sequence $write,
+    ) {
+    }
+
+    /**
+     * @param Maybe<Period> $timeout
+     * @param Sequence<Stream|Server> $read
+     * @param Sequence<Stream> $write
+     */
+    public static function of(
+        PointInTime $at,
+        Maybe $timeout,
+        Sequence $read,
+        Sequence $write,
+    ): self {
+        return new self(
+            $at,
+            $timeout,
+            $read,
+            $write,
+        );
+    }
+
+    /**
+     * @return Maybe<Period>
+     */
+    public function timeout(): Maybe
+    {
+        return $this->timeout;
+    }
+
+    /**
+     * @return Sequence<Stream|Server>
+     */
+    public function read(): Sequence
+    {
+        return $this->read;
+    }
+
+    /**
+     * @return Sequence<Stream>
+     */
+    public function write(): Sequence
+    {
+        return $this->write;
+    }
+
+    public function next(
+        Clock $clock,
+        Ready $ready,
+    ): self|Resumable {
+        $read = $this->read->intersect($ready->toRead());
+        $write = $this->write->intersect($ready->toWrite());
+
+        if (!$read->empty() || !$write->empty()) {
+            return Resumable::of(new Ready($read, $write));
+        }
+
+        $timedout = $this
+            ->timeout
+            ->map(static fn($period) => $period->asElapsedPeriod())
+            ->filter(
+                fn($threshold) => $clock
+                    ->now()
+                    ->elapsedSince($this->at)
+                    ->longerThan($threshold),
+            )
+            ->match(
+                static fn() => true,
+                static fn() => false,
+            );
+
+        if ($timedout) {
+            return Resumable::of(new Ready(
+                Sequence::of(),
+                Sequence::of(),
+            ));
+        }
+
+        return $this;
+    }
+}

--- a/src/Internal/Capabilities/Files.php
+++ b/src/Internal/Capabilities/Files.php
@@ -71,6 +71,6 @@ final class Files
             return Attempt::error(new RuntimeException("Failed to open file '$path'"));
         }
 
-        return Attempt::result(Stream::of($stream));
+        return Attempt::result(Stream::file($stream));
     }
 }

--- a/src/Internal/Stream.php
+++ b/src/Internal/Stream.php
@@ -34,6 +34,7 @@ final class Stream
 {
     /** @var resource */
     private $resource;
+    private bool $file;
     private bool $closed = false;
     private bool $seekable = false;
     private bool $syncable = false;
@@ -41,7 +42,7 @@ final class Stream
     /**
      * @param resource $resource
      */
-    private function __construct($resource)
+    private function __construct($resource, bool $file)
     {
         /**
          * @psalm-suppress DocblockTypeContradiction
@@ -52,6 +53,7 @@ final class Stream
         }
 
         $this->resource = $resource;
+        $this->file = $file;
         $meta = \stream_get_meta_data($resource);
 
         if ($meta['seekable'] && \substr($meta['uri'], 0, 9) !== 'php://std') {
@@ -72,7 +74,22 @@ final class Stream
      */
     public static function of($resource): self
     {
-        return new self($resource);
+        return new self($resource, false);
+    }
+
+    /**
+     * @internal
+     *
+     * @param resource $resource
+     */
+    public static function file($resource): self
+    {
+        return new self($resource, true);
+    }
+
+    public function isFile(): bool
+    {
+        return $this->file;
     }
 
     /**

--- a/src/Internal/Watch.php
+++ b/src/Internal/Watch.php
@@ -86,24 +86,20 @@ final class Watch
     /**
      * @psalm-mutation-free
      */
-    public function forRead(
-        Stream|Server $read,
-        Stream|Server ...$reads,
-    ): self {
+    public function forRead(Stream|Server $read): self
+    {
         return new self(
-            $this->implementation->forRead($read, ...$reads),
+            $this->implementation->forRead($read),
         );
     }
 
     /**
      * @psalm-mutation-free
      */
-    public function forWrite(
-        Stream $write,
-        Stream ...$writes,
-    ): self {
+    public function forWrite(Stream $write): self
+    {
         return new self(
-            $this->implementation->forWrite($write, ...$writes),
+            $this->implementation->forWrite($write),
         );
     }
 

--- a/src/Internal/Watch.php
+++ b/src/Internal/Watch.php
@@ -4,17 +4,16 @@ declare(strict_types = 1);
 namespace Innmind\IO\Internal;
 
 use Innmind\IO\{
+    Internal\Watch\Sync,
+    Internal\Watch\Async,
     Internal\Watch\Ready,
     Internal\Socket\Server,
-    Exception\RuntimeException,
 };
-use Innmind\TimeContinuum\Period;
-use Innmind\Immutable\{
-    Map,
-    Sequence,
-    Maybe,
-    Attempt
+use Innmind\TimeContinuum\{
+    Clock,
+    Period,
 };
+use Innmind\Immutable\Attempt;
 
 /**
  * @internal
@@ -24,15 +23,9 @@ final class Watch
 {
     /**
      * @psalm-mutation-free
-     *
-     * @param Maybe<Period> $timeout
-     * @param Map<resource, Stream|Server> $read
-     * @param Map<resource, Stream> $write
      */
     private function __construct(
-        private Maybe $timeout,
-        private Map $read,
-        private Map $write,
+        private Sync|Async $implementation,
     ) {
     }
 
@@ -41,67 +34,25 @@ final class Watch
      */
     public function __invoke(): Attempt
     {
-        if (
-            $this->read->empty() &&
-            $this->write->empty()
-        ) {
-            /** @var Sequence<Stream|Server> */
-            $read = Sequence::of();
-            /** @var Sequence<Stream> */
-            $write = Sequence::of();
-
-            return Attempt::result(new Ready($read, $write));
-        }
-
-        $read = $this->read->keys()->toList();
-        $write = $this->write->keys()->toList();
-        $outOfBand = [];
-        [$seconds, $microseconds] = $this
-            ->timeout
-            ->match(
-                self::timeout(...),
-                static fn() => [null, null],
-            );
-
-        $return = @\stream_select(
-            $read,
-            $write,
-            $outOfBand,
-            $seconds,
-            $microseconds,
-        );
-
-        if ($return === false) {
-            /** @var Attempt<Ready> */
-            return Attempt::error(new RuntimeException);
-        }
-
-        $readable = $this
-            ->read
-            ->filter(static fn($resource) => \in_array($resource, $read, true))
-            ->values();
-        $writable = $this
-            ->write
-            ->filter(static fn($resource) => \in_array($resource, $write, true))
-            ->values();
-
-        return Attempt::result(new Ready($readable, $writable));
+        return ($this->implementation)();
     }
 
     /**
      * @internal
      * @psalm-pure
      */
-    public static function new(): self
+    public static function sync(): self
     {
-        /** @var Maybe<Period> */
-        $timeout = Maybe::nothing();
+        return new self(Sync::new());
+    }
 
-        return new self(
-            $timeout,
-            Map::of(),
-            Map::of(),
-        );
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function async(Clock $clock): self
+    {
+        return new self(Async::new($clock));
     }
 
     /**
@@ -110,9 +61,7 @@ final class Watch
     public function timeoutAfter(Period $timeout): self
     {
         return new self(
-            Maybe::just($timeout),
-            $this->read,
-            $this->write,
+            $this->implementation->timeoutAfter($timeout),
         );
     }
 
@@ -121,13 +70,8 @@ final class Watch
      */
     public function waitForever(): self
     {
-        /** @var Maybe<Period> */
-        $timeout = Maybe::nothing();
-
         return new self(
-            $timeout,
-            $this->read,
-            $this->write,
+            $this->implementation->waitForever(),
         );
     }
 
@@ -146,22 +90,8 @@ final class Watch
         Stream|Server $read,
         Stream|Server ...$reads,
     ): self {
-        $streams = ($this->read)(
-            $read->resource(),
-            $read,
-        );
-
-        foreach ($reads as $read) {
-            $streams = $streams(
-                $read->resource(),
-                $read,
-            );
-        }
-
         return new self(
-            $this->timeout,
-            $streams,
-            $this->write,
+            $this->implementation->forRead($read, ...$reads),
         );
     }
 
@@ -172,22 +102,8 @@ final class Watch
         Stream $write,
         Stream ...$writes,
     ): self {
-        $streams = ($this->write)(
-            $write->resource(),
-            $write,
-        );
-
-        foreach ($writes as $write) {
-            $streams = $streams(
-                $write->resource(),
-                $write,
-            );
-        }
-
         return new self(
-            $this->timeout,
-            $this->read,
-            $streams,
+            $this->implementation->forWrite($write, ...$writes),
         );
     }
 
@@ -198,19 +114,15 @@ final class Watch
      */
     public function merge(self $other): self
     {
-        $ownTimeout = $this->timeout;
-        $otherTimeout = $other->timeout;
+        $type = \get_class($other->implementation);
 
+        if (!($this->implementation instanceof $type)) {
+            throw new \LogicException('Sync and async IO cannot be done at the same time');
+        }
+
+        /** @psalm-suppress PossiblyInvalidArgument */
         return new self(
-            Maybe::all($ownTimeout, $otherTimeout)
-                ->map(static fn(Period $own, Period $other) => match (true) {
-                    $own->asElapsedPeriod()->longerThan($other->asElapsedPeriod()) => $other,
-                    default => $own,
-                })
-                ->otherwise(static fn() => $ownTimeout)
-                ->otherwise(static fn() => $otherTimeout),
-            $this->read->merge($other->read),
-            $this->write->merge($other->write),
+            $this->implementation->merge($other->implementation),
         );
     }
 
@@ -219,12 +131,8 @@ final class Watch
      */
     public function unwatch(Stream|Server $stream): self
     {
-        $resource = $stream->resource();
-
         return new self(
-            $this->timeout,
-            $this->read->remove($resource),
-            $this->write->remove($resource),
+            $this->implementation->unwatch($stream),
         );
     }
 
@@ -233,17 +141,8 @@ final class Watch
      */
     public function clear(): self
     {
-        return self::new();
-    }
-
-    /**
-     * @return array{0: int, 1: int}
-     */
-    private static function timeout(Period $timeout): array
-    {
-        $seconds = $timeout->seconds();
-        $microseconds = ($timeout->milliseconds() * 1_000) + $timeout->microseconds();
-
-        return [$seconds, $microseconds];
+        return new self(
+            $this->implementation->clear(),
+        );
     }
 }

--- a/src/Internal/Watch/Async.php
+++ b/src/Internal/Watch/Async.php
@@ -102,16 +102,14 @@ final class Async
     /**
      * @psalm-mutation-free
      */
-    public function forRead(
-        Stream|Server $read,
-        Stream|Server ...$reads,
-    ): self {
+    public function forRead(Stream|Server $read): self
+    {
         return new self(
             $this->clock,
             $this->timeout,
             $this
                 ->read
-                ->append(Sequence::of($read, ...$reads))
+                ->add($read)
                 ->distinct(),
             $this->write,
         );
@@ -120,17 +118,15 @@ final class Async
     /**
      * @psalm-mutation-free
      */
-    public function forWrite(
-        Stream $write,
-        Stream ...$writes,
-    ): self {
+    public function forWrite(Stream $write): self
+    {
         return new self(
             $this->clock,
             $this->timeout,
             $this->read,
             $this
                 ->write
-                ->append(Sequence::of($write, ...$writes))
+                ->add($write)
                 ->distinct(),
         );
     }

--- a/src/Internal/Watch/Async.php
+++ b/src/Internal/Watch/Async.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\IO\Internal\Watch;
+
+use Innmind\IO\{
+    Internal\Stream,
+    Internal\Socket\Server,
+    Internal\Async\Suspended,
+};
+use Innmind\TimeContinuum\{
+    Clock,
+    Period,
+};
+use Innmind\Immutable\{
+    Sequence,
+    Maybe,
+    Attempt,
+};
+
+/**
+ * @internal
+ * By default it waits forever for changes
+ */
+final class Async
+{
+    /**
+     * @psalm-mutation-free
+     *
+     * @param Maybe<Period> $timeout
+     * @param Sequence<Stream|Server> $read
+     * @param Sequence<Stream> $write
+     */
+    private function __construct(
+        private Clock $clock,
+        private Maybe $timeout,
+        private Sequence $read,
+        private Sequence $write,
+    ) {
+    }
+
+    /**
+     * @return Attempt<Ready>
+     */
+    public function __invoke(): Attempt
+    {
+        /** @var Attempt<Ready> */
+        return \Fiber::suspend(Suspended::of(
+            $this->clock->now(),
+            $this->timeout,
+            $this->read,
+            $this->write,
+        ));
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function new(Clock $clock): self
+    {
+        /** @var Maybe<Period> */
+        $timeout = Maybe::nothing();
+
+        return new self(
+            $clock,
+            $timeout,
+            Sequence::of(),
+            Sequence::of(),
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function timeoutAfter(Period $timeout): self
+    {
+        return new self(
+            $this->clock,
+            Maybe::just($timeout),
+            $this->read,
+            $this->write,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function waitForever(): self
+    {
+        /** @var Maybe<Period> */
+        $timeout = Maybe::nothing();
+
+        return new self(
+            $this->clock,
+            $timeout,
+            $this->read,
+            $this->write,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function forRead(
+        Stream|Server $read,
+        Stream|Server ...$reads,
+    ): self {
+        return new self(
+            $this->clock,
+            $this->timeout,
+            $this
+                ->read
+                ->append(Sequence::of($read, ...$reads))
+                ->distinct(),
+            $this->write,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function forWrite(
+        Stream $write,
+        Stream ...$writes,
+    ): self {
+        return new self(
+            $this->clock,
+            $this->timeout,
+            $this->read,
+            $this
+                ->write
+                ->append(Sequence::of($write, ...$writes))
+                ->distinct(),
+        );
+    }
+
+    /**
+     * The new Watch uses the shortest timeout of the both.
+     *
+     * @psalm-mutation-free
+     */
+    public function merge(self $other): self
+    {
+        $ownTimeout = $this->timeout;
+        $otherTimeout = $other->timeout;
+
+        return new self(
+            $this->clock,
+            Maybe::all($ownTimeout, $otherTimeout)
+                ->map(static fn(Period $own, Period $other) => match (true) {
+                    $own->asElapsedPeriod()->longerThan($other->asElapsedPeriod()) => $other,
+                    default => $own,
+                })
+                ->otherwise(static fn() => $ownTimeout)
+                ->otherwise(static fn() => $otherTimeout),
+            $this->read->append($other->read)->distinct(),
+            $this->write->append($other->write)->distinct(),
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function unwatch(Stream|Server $stream): self
+    {
+        return new self(
+            $this->clock,
+            $this->timeout,
+            $this->read->exclude(static fn($known) => $known === $stream),
+            $this->write->exclude(static fn($known) => $known === $stream),
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function clear(): self
+    {
+        return self::new($this->clock);
+    }
+}

--- a/src/Internal/Watch/Sync.php
+++ b/src/Internal/Watch/Sync.php
@@ -134,25 +134,14 @@ final class Sync
     /**
      * @psalm-mutation-free
      */
-    public function forRead(
-        Stream|Server $read,
-        Stream|Server ...$reads,
-    ): self {
-        $streams = ($this->read)(
-            $read->resource(),
-            $read,
-        );
-
-        foreach ($reads as $read) {
-            $streams = $streams(
-                $read->resource(),
-                $read,
-            );
-        }
-
+    public function forRead(Stream|Server $read): self
+    {
         return new self(
             $this->timeout,
-            $streams,
+            ($this->read)(
+                $read->resource(),
+                $read,
+            ),
             $this->write,
         );
     }
@@ -160,26 +149,15 @@ final class Sync
     /**
      * @psalm-mutation-free
      */
-    public function forWrite(
-        Stream $write,
-        Stream ...$writes,
-    ): self {
-        $streams = ($this->write)(
-            $write->resource(),
-            $write,
-        );
-
-        foreach ($writes as $write) {
-            $streams = $streams(
-                $write->resource(),
-                $write,
-            );
-        }
-
+    public function forWrite(Stream $write): self
+    {
         return new self(
             $this->timeout,
             $this->read,
-            $streams,
+            ($this->write)(
+                $write->resource(),
+                $write,
+            ),
         );
     }
 

--- a/src/Internal/Watch/Sync.php
+++ b/src/Internal/Watch/Sync.php
@@ -1,0 +1,241 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\IO\Internal\Watch;
+
+use Innmind\IO\{
+    Internal\Stream,
+    Internal\Socket\Server,
+    Exception\RuntimeException,
+};
+use Innmind\TimeContinuum\Period;
+use Innmind\Immutable\{
+    Map,
+    Sequence,
+    Maybe,
+    Attempt
+};
+
+/**
+ * @internal
+ * By default it waits forever for changes
+ */
+final class Sync
+{
+    /**
+     * @psalm-mutation-free
+     *
+     * @param Maybe<Period> $timeout
+     * @param Map<resource, Stream|Server> $read
+     * @param Map<resource, Stream> $write
+     */
+    private function __construct(
+        private Maybe $timeout,
+        private Map $read,
+        private Map $write,
+    ) {
+    }
+
+    /**
+     * @return Attempt<Ready>
+     */
+    public function __invoke(): Attempt
+    {
+        if (
+            $this->read->empty() &&
+            $this->write->empty()
+        ) {
+            /** @var Sequence<Stream|Server> */
+            $read = Sequence::of();
+            /** @var Sequence<Stream> */
+            $write = Sequence::of();
+
+            return Attempt::result(new Ready($read, $write));
+        }
+
+        $read = $this->read->keys()->toList();
+        $write = $this->write->keys()->toList();
+        $outOfBand = [];
+        [$seconds, $microseconds] = $this
+            ->timeout
+            ->match(
+                self::timeout(...),
+                static fn() => [null, null],
+            );
+
+        $return = @\stream_select(
+            $read,
+            $write,
+            $outOfBand,
+            $seconds,
+            $microseconds,
+        );
+
+        if ($return === false) {
+            /** @var Attempt<Ready> */
+            return Attempt::error(new RuntimeException);
+        }
+
+        $readable = $this
+            ->read
+            ->filter(static fn($resource) => \in_array($resource, $read, true))
+            ->values();
+        $writable = $this
+            ->write
+            ->filter(static fn($resource) => \in_array($resource, $write, true))
+            ->values();
+
+        return Attempt::result(new Ready($readable, $writable));
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     */
+    public static function new(): self
+    {
+        /** @var Maybe<Period> */
+        $timeout = Maybe::nothing();
+
+        return new self(
+            $timeout,
+            Map::of(),
+            Map::of(),
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function timeoutAfter(Period $timeout): self
+    {
+        return new self(
+            Maybe::just($timeout),
+            $this->read,
+            $this->write,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function waitForever(): self
+    {
+        /** @var Maybe<Period> */
+        $timeout = Maybe::nothing();
+
+        return new self(
+            $timeout,
+            $this->read,
+            $this->write,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function forRead(
+        Stream|Server $read,
+        Stream|Server ...$reads,
+    ): self {
+        $streams = ($this->read)(
+            $read->resource(),
+            $read,
+        );
+
+        foreach ($reads as $read) {
+            $streams = $streams(
+                $read->resource(),
+                $read,
+            );
+        }
+
+        return new self(
+            $this->timeout,
+            $streams,
+            $this->write,
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function forWrite(
+        Stream $write,
+        Stream ...$writes,
+    ): self {
+        $streams = ($this->write)(
+            $write->resource(),
+            $write,
+        );
+
+        foreach ($writes as $write) {
+            $streams = $streams(
+                $write->resource(),
+                $write,
+            );
+        }
+
+        return new self(
+            $this->timeout,
+            $this->read,
+            $streams,
+        );
+    }
+
+    /**
+     * The new Watch uses the shortest timeout of the both.
+     *
+     * @psalm-mutation-free
+     */
+    public function merge(self $other): self
+    {
+        $ownTimeout = $this->timeout;
+        $otherTimeout = $other->timeout;
+
+        return new self(
+            Maybe::all($ownTimeout, $otherTimeout)
+                ->map(static fn(Period $own, Period $other) => match (true) {
+                    $own->asElapsedPeriod()->longerThan($other->asElapsedPeriod()) => $other,
+                    default => $own,
+                })
+                ->otherwise(static fn() => $ownTimeout)
+                ->otherwise(static fn() => $otherTimeout),
+            $this->read->merge($other->read),
+            $this->write->merge($other->write),
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function unwatch(Stream|Server $stream): self
+    {
+        $resource = $stream->resource();
+
+        return new self(
+            $this->timeout,
+            $this->read->remove($resource),
+            $this->write->remove($resource),
+        );
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function clear(): self
+    {
+        return self::new();
+    }
+
+    /**
+     * @return array{0: int, 1: int}
+     */
+    private static function timeout(Period $timeout): array
+    {
+        $seconds = $timeout->seconds();
+        $microseconds = ($timeout->milliseconds() * 1_000) + $timeout->microseconds();
+
+        return [$seconds, $microseconds];
+    }
+}


### PR DESCRIPTION
This is intended for the new [`innmind/async` package](https://github.com/Innmind/async/pull/1).

The value returned by the Fiber suspension contains everything to watch the streams synchronously and combine it with other fibers' suspension. And it also self contain if the Fiber can be resumed or not depending on the result of the synchronous watch.